### PR TITLE
fix: Remove reference to nonexistent `duckplyr::left_join()`

### DIFF
--- a/tests/tests_rafa/merge_household_notes.R
+++ b/tests/tests_rafa/merge_household_notes.R
@@ -96,7 +96,7 @@ merge_household_var <- function(df, year, add_labels=NULL, showProgress=T){
   df_household <- arrow::to_duckdb(df_household)
 
   # merge
-  gf_geo <- duckplyr::left_join(df, df_household)
+  gf_geo <- dplyr::left_join(df, df_household)
 
   # back to arrow
   gf_geo <- arrow::to_arrow(gf_geo)

--- a/tests/tests_rafa/test_duckdb_merge.R
+++ b/tests/tests_rafa/test_duckdb_merge.R
@@ -98,7 +98,7 @@ df <- arrow::to_duckdb(df)
 df_household <- arrow::to_duckdb(df_household)
 
 # merge
-df_geo <- duckplyr::left_join(df, df_household)
+df_geo <- dplyr::left_join(df, df_household)
 
 # back to arrow
 df_geo <- arrow::to_arrow(df_geo)
@@ -259,7 +259,7 @@ merge_fun <- function(arrow1, arrow2){
   arrow2 <- arrow::to_duckdb(arrow2)
 
   # merge
-  df_merge <- duckplyr::left_join(arrow1, arrow2) |>
+  df_merge <- dplyr::left_join(arrow1, arrow2) |>
             dplyr::compute()
 
   # ?????? duckdb::duckdb_unregister()

--- a/tests/tests_rafa/test_duckdb_merge2.R
+++ b/tests/tests_rafa/test_duckdb_merge2.R
@@ -39,7 +39,7 @@ merge_fun <- function(arrow1, arrow2){
 
 
   # merge
-  df_merge <- duckplyr::left_join(dplyr::tbl(con, "arrow1"),
+  df_merge <- dplyr::left_join(dplyr::tbl(con, "arrow1"),
                                   dplyr::tbl(con, "arrow2"),)
 
   df_merge <- dplyr::compute(df_merge)


### PR DESCRIPTION
The upcoming duckplyr 1.0.0 no longer reexports all of dplyr. This blocks CRAN submission. I'll ask CRAN to proceed because it looks like these files are never actually run.

The articles at https://duckplyr.tidyverse.org/articles/ describe how to work with the API. Happy to support you using duckplyr as the engine in this package, I think it's a good fit. Start by replacing `arrow_open_dataset()` with `duckplyr::read_parquet_duckdb()`, let me know if you have any questions!